### PR TITLE
Add initial version of composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "onoffice/sdk",
+    "description": "Official client to communicate with the onOffice API",
+    "license": "MIT",
+    "require": {}
+}


### PR DESCRIPTION
I noticed that this project has currently no `composer.json` so I added one :)

# Why composer?

[Composer](https://getcomposer.org/) is the (probably) the most common tool to define and deploy new PHP packages in the Open Source community.

A `composer.json` is also necessary for adding this library to [packagist](https://packagist.org/) so it can be accessed via `$ composer require`.


Feel free to give me feedback on this 👍 