### PR TITLE
Add CONTRIBUTING.md to create a process of external contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing
+
+When contributing to this service,
+please open an issue on
+[GitHub issues](https://github.com/onOfficeGmbH/sdk/issues)
+or send a mail to `apisupport@onoffice.de`
+this service before making a change.
+
+## Bugs
+
+Bugs must be reported via the
+[GitHub issues](https://github.com/onOfficeGmbH/sdk/issues)
+Bug fixes and improvements can be provided via a Pull Request.
+
+A fix that redefines that behaviour of an implementation are considered
+as a [breaking change](#breaking-changes).
+
+## Features
+
+Features and Breaking Changes must be discussed with the
+maintainers of this repository.
+
+Features that also changes the behaviour of existing implementations
+are considered as [breaking changes](#breaking-changes).
+
+## Breaking Changes
+
+A breaking change must be discussed with the maintainers.
+The list of maintainers can be found [here](https://github.com/orgs/onOfficeGmbH/people)
+
+## Pull Request Process
+
+* Update the `README.md` with details of changes to the interface, classes or
+  general behaviour.
+* Contact one of the maintainers in the Pull Request.
+  The list of maintainers can be found [here](https://github.com/orgs/onOfficeGmbH/people)
+* Every Pull Request with actual code changes has to add or adapt unit tests.
+* Create a meaningful title for the Pull Request that addresses the topic.
+* The Pull Request must pass the CI integration.
+  Be aware of the currently supported PHP versions and optimize your code according
+  to the supported versions.
+* Keep the Pull Request as small as possible.
+  Avoid unnecessary changes to speed up the review process.
+* Use readable and understandable commit messages, so the reviewer can understand the
+  intention of each commit.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,18 @@
 # Contributing
 
 When contributing to this service,
-please open an issue on
-[GitHub issues](https://github.com/onOfficeGmbH/sdk/issues)
+please open an issue via the
+[GitHub issues page](https://github.com/onOfficeGmbH/sdk/issues)
 or send a mail to `apisupport@onoffice.de`
 before making a change.
 
 ## Bugs
 
 Bugs must be reported via the
-[GitHub issues](https://github.com/onOfficeGmbH/sdk/issues)
-Bug fixes and improvements can be provided via a Pull Request.
+[GitHub issues page](https://github.com/onOfficeGmbH/sdk/issues).
+
+Bug fixes and improvements can be provided via a
+[Pull Request](https://github.com/onOfficeGmbH/sdk/pulls).
 
 A fix that introduces a change in behavior is considered a
 [breaking change](#breaking-changes).
@@ -21,7 +23,7 @@ Features and Breaking Changes must be discussed with the
 maintainers of this repository.
 
 Features that also change the behaviour of existing implementations
-are considered as [breaking changes](#breaking-changes).
+are considered [breaking changes](#breaking-changes).
 
 ## Breaking Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ When contributing to this service,
 please open an issue on
 [GitHub issues](https://github.com/onOfficeGmbH/sdk/issues)
 or send a mail to `apisupport@onoffice.de`
-this service before making a change.
+before making a change.
 
 ## Bugs
 
@@ -12,15 +12,15 @@ Bugs must be reported via the
 [GitHub issues](https://github.com/onOfficeGmbH/sdk/issues)
 Bug fixes and improvements can be provided via a Pull Request.
 
-A fix that redefines that behaviour of an implementation are considered
-as a [breaking change](#breaking-changes).
+A fix that introduces a change in behavior is considered a
+[breaking change](#breaking-changes).
 
 ## Features
 
 Features and Breaking Changes must be discussed with the
 maintainers of this repository.
 
-Features that also changes the behaviour of existing implementations
+Features that also change the behaviour of existing implementations
 are considered as [breaking changes](#breaking-changes).
 
 ## Breaking Changes
@@ -41,5 +41,7 @@ The list of maintainers can be found [here](https://github.com/orgs/onOfficeGmbH
   to the supported versions.
 * Keep the Pull Request as small as possible.
   Avoid unnecessary changes to speed up the review process.
+* Write readable and understandable code.
+  Try always to create the best possible solution.
 * Use readable and understandable commit messages, so the reviewer can understand the
   intention of each commit.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,8 @@ A fix that introduces a change in behavior is considered a
 Features and Breaking Changes must be discussed with the
 maintainers of this repository.
 
-Features that also change the behaviour of existing implementations
-are considered [breaking changes](#breaking-changes).
+A feature that introduces a change in existing behavior is considered a
+[breaking change](#breaking-changes).
 
 ## Breaking Changes
 

--- a/README.md
+++ b/README.md
@@ -141,9 +141,9 @@ Additional information about the API can be [found here](https://apidoc.onoffice
 
 ## Contributing
 
-If you want to contribute to this project, we would appreciate if you send us an email to
+You want to contribute? Great!
 
-apisupport@onoffice.de
+Check out our [contribution rules](/CONTRIBUTING.md) and get started!
 
 ## License
 


### PR DESCRIPTION
This PR adds `CONTRIBUTING.md` as recommend on: https://help.github.com/en/github/building-a-strong-community/setting-guidelines-for-repository-contributors

I've added some rules here, but feel free to give me feedback on them 👍 