### PR TITLE
Add external dependencies curl and json to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,8 @@
     "name": "onoffice/sdk",
     "description": "Official client to communicate with the onOffice API",
     "license": "MIT",
-    "require": {}
+    "require": {
+        "ext-json": "*",
+        "ext-curl": "*"
+    }
 }


### PR DESCRIPTION
Functions like `json_encode`, `json_decode` and `curl` are not part of vanilla PHP.
So it makes sense to add these as dependency to the `composer,json`.
