### PR TITLE
Add Travis (via .travis.yml) to CI pipline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,3 @@ language: php
 
 php:
   - 7
-
-sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: php
+
+php:
+  - 7
+
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: php
 
 php:
   - 7
+
+install:
+  - composer install --no-interaction
+  - if [ "$DEPENDENCIES" = "lowest" ]; then composer update --prefer-lowest -n; fi


### PR DESCRIPTION
Introduce [Travis CI](https://travis-ci.com/) as our CI service.

This should help us create a CI pipline to ease our release cycles in the future.

This file contain much (yet!), but in one of the upcoming PRs we will intodruce e.g. PHPUnit, which will be part of our CI pipeline.

Relevant Issues: #8