### PR TITLE
Fix composer command to install dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The recommended way to install this library is through Composer.
 This will install the latest supported version:
 
 ```
-$ composer install onoffice/sdk:^0.1.0
+$ composer require onoffice/sdk:^0.1.0
 ```
 See also the [CHANGELOG](/CHANGELOG.md)
 for details about version upgrades.


### PR DESCRIPTION
Hi,
The composer install command is used to install dependencies from an existing composer.lock file. To install a new dependency, require is the correct command.
Kind regards!