### PR TITLE
Add test case for onOfficeSDK class

### DIFF
--- a/src/onOfficeSDK.php
+++ b/src/onOfficeSDK.php
@@ -71,14 +71,16 @@ class onOfficeSDK
 	/** @var ApiCall */
 	private $_pApiCall = null;
 
-
 	/**
-	 *
+	 * @param ApiCall|null $pApiCall
 	 */
 
-	public function __construct()
+	public function __construct(ApiCall $pApiCall = null)
 	{
-		$this->_pApiCall = new ApiCall();
+		if (null === $pApiCall) {
+			$pApiCall = new ApiCall();
+		}
+		$this->_pApiCall = $pApiCall;
 		$this->_pApiCall->setServer('https://api.onoffice.de/api/');
 	}
 

--- a/tests/onOfficeSDKTest.php
+++ b/tests/onOfficeSDKTest.php
@@ -9,8 +9,7 @@ class onOfficeSDKTest extends \PHPUnit\Framework\TestCase
 			->setMethods(['setServer'])
 			->getMock();
 
-		$apiCall
-			->expects($this->once())
+		$apiCall->expects($this->once())
 			->method('setServer')
 			->with('https://api.onoffice.de/api/');
 
@@ -25,13 +24,11 @@ class onOfficeSDKTest extends \PHPUnit\Framework\TestCase
 			->setMethods(['setServer', 'setApiVersion'])
 			->getMock();
 
-		$apiCall
-			->expects($this->once())
+		$apiCall->expects($this->once())
 			->method('setServer')
 			->with('https://api.onoffice.de/api/');
 
-		$apiCall
-			->expects($this->once())
+		$apiCall->expects($this->once())
 			->method('setApiVersion')
 			->with('v1');
 
@@ -46,13 +43,11 @@ class onOfficeSDKTest extends \PHPUnit\Framework\TestCase
 			->setMethods(['setServer', 'setCurlOptions'])
 			->getMock();
 
-		$apiCall
-			->expects($this->once())
+		$apiCall->expects($this->once())
 			->method('setServer')
 			->with('https://api.onoffice.de/api/');
 
-		$apiCall
-			->expects($this->once())
+		$apiCall->expects($this->once())
 			->method('setCurlOptions')
 			->with(['some', 'actions']);
 
@@ -67,13 +62,11 @@ class onOfficeSDKTest extends \PHPUnit\Framework\TestCase
 			->setMethods(['setServer', 'callByRawData'])
 			->getMock();
 
-		$apiCall
-			->expects($this->once())
+		$apiCall->expects($this->once())
 			->method('setServer')
 			->with('https://api.onoffice.de/api/');
 
-		$apiCall
-			->expects($this->once())
+		$apiCall->expects($this->once())
 			->method('callByRawData')
 			->with(
 				'someActionId',
@@ -98,13 +91,11 @@ class onOfficeSDKTest extends \PHPUnit\Framework\TestCase
 			->setMethods(['setServer', 'sendRequests'])
 			->getMock();
 
-		$apiCall
-			->expects($this->once())
+		$apiCall->expects($this->once())
 			->method('setServer')
 			->with('https://api.onoffice.de/api/');
 
-		$apiCall
-			->expects($this->once())
+		$apiCall->expects($this->once())
 			->method('sendRequests')
 			->with(
 				'someToken',
@@ -125,13 +116,11 @@ class onOfficeSDKTest extends \PHPUnit\Framework\TestCase
 			->setMethods(['setServer', 'getResponse'])
 			->getMock();
 
-		$apiCall
-			->expects($this->once())
+		$apiCall->expects($this->once())
 			->method('setServer')
 			->with('https://api.onoffice.de/api/');
 
-		$apiCall
-			->expects($this->once())
+		$apiCall->expects($this->once())
 			->method('getResponse')
 			->with(1)
 			->willReturn(['some', 'response']);
@@ -149,16 +138,14 @@ class onOfficeSDKTest extends \PHPUnit\Framework\TestCase
 			->setMethods(['setServer', 'addCache'])
 			->getMock();
 
-		$apiCall
-			->expects($this->once())
+		$apiCall->expects($this->once())
 			->method('setServer')
 			->with('https://api.onoffice.de/api/');
 
 		$cache = $this->getMockBuilder(\onOffice\SDK\Cache\onOfficeSDKCache::class)
 			->getMock();
 
-		$apiCall
-			->expects($this->once())
+		$apiCall->expects($this->once())
 			->method('addCache')
 			->with($cache);
 

--- a/tests/onOfficeSDKTest.php
+++ b/tests/onOfficeSDKTest.php
@@ -1,0 +1,169 @@
+<?php
+
+class onOfficeSDKTest extends \PHPUnit\Framework\TestCase
+{
+	public function testCreationOfClient()
+	{
+		$apiCall = $this->getMockBuilder(\onOffice\SDK\internal\ApiCall::class)
+			->disableOriginalConstructor()
+			->setMethods(['setServer'])
+			->getMock();
+
+		$apiCall
+			->expects($this->once())
+			->method('setServer')
+			->with('https://api.onoffice.de/api/');
+
+		$onOfficeSdk = new \onOffice\SDK\onOfficeSDK($apiCall);
+	}
+
+
+	public function testSetApiVerision()
+	{
+		$apiCall = $this->getMockBuilder(\onOffice\SDK\internal\ApiCall::class)
+			->disableOriginalConstructor()
+			->setMethods(['setServer', 'setApiVersion'])
+			->getMock();
+
+		$apiCall
+			->expects($this->once())
+			->method('setServer')
+			->with('https://api.onoffice.de/api/');
+
+		$apiCall
+			->expects($this->once())
+			->method('setApiVersion')
+			->with('v1');
+
+		$onOfficeSdk = new \onOffice\SDK\onOfficeSDK($apiCall);
+		$onOfficeSdk->setApiVersion('v1');
+	}
+
+	public function testSetApiCurlOptions()
+	{
+		$apiCall = $this->getMockBuilder(\onOffice\SDK\internal\ApiCall::class)
+			->disableOriginalConstructor()
+			->setMethods(['setServer', 'setCurlOptions'])
+			->getMock();
+
+		$apiCall
+			->expects($this->once())
+			->method('setServer')
+			->with('https://api.onoffice.de/api/');
+
+		$apiCall
+			->expects($this->once())
+			->method('setCurlOptions')
+			->with(['some', 'actions']);
+
+		$onOfficeSdk = new \onOffice\SDK\onOfficeSDK($apiCall);
+		$onOfficeSdk->setApiCurlOptions(['some', 'actions']);
+	}
+
+	public function testCallGeneric()
+	{
+		$apiCall = $this->getMockBuilder(\onOffice\SDK\internal\ApiCall::class)
+			->disableOriginalConstructor()
+			->setMethods(['setServer', 'callByRawData'])
+			->getMock();
+
+		$apiCall
+			->expects($this->once())
+			->method('setServer')
+			->with('https://api.onoffice.de/api/');
+
+		$apiCall
+			->expects($this->once())
+			->method('callByRawData')
+			->with(
+				'someActionId',
+				'',
+				'',
+				'someResourceType',
+				['some', 'parameters']
+			);
+
+		$onOfficeSdk = new \onOffice\SDK\onOfficeSDK($apiCall);
+		$onOfficeSdk->callGeneric(
+			'someActionId',
+			'someResourceType',
+			['some', 'parameters']
+		);
+	}
+
+	public function testSendRequests()
+	{
+		$apiCall = $this->getMockBuilder(\onOffice\SDK\internal\ApiCall::class)
+			->disableOriginalConstructor()
+			->setMethods(['setServer', 'sendRequests'])
+			->getMock();
+
+		$apiCall
+			->expects($this->once())
+			->method('setServer')
+			->with('https://api.onoffice.de/api/');
+
+		$apiCall
+			->expects($this->once())
+			->method('sendRequests')
+			->with(
+				'someToken',
+				'someSecret'
+			);
+
+		$onOfficeSdk = new \onOffice\SDK\onOfficeSDK($apiCall);
+		$onOfficeSdk->sendRequests(
+			'someToken',
+			'someSecret'
+		);
+	}
+
+	public function testGetResponseArray()
+	{
+		$apiCall = $this->getMockBuilder(\onOffice\SDK\internal\ApiCall::class)
+			->disableOriginalConstructor()
+			->setMethods(['setServer', 'getResponse'])
+			->getMock();
+
+		$apiCall
+			->expects($this->once())
+			->method('setServer')
+			->with('https://api.onoffice.de/api/');
+
+		$apiCall
+			->expects($this->once())
+			->method('getResponse')
+			->with(1)
+			->willReturn(['some', 'response']);
+
+		$onOfficeSdk = new \onOffice\SDK\onOfficeSDK($apiCall);
+		$result = $onOfficeSdk->getResponseArray(1);
+
+		$this->assertEquals(['some', 'response'], $result);
+	}
+
+	public function testAddCache()
+	{
+		$apiCall = $this->getMockBuilder(\onOffice\SDK\internal\ApiCall::class)
+			->disableOriginalConstructor()
+			->setMethods(['setServer', 'addCache'])
+			->getMock();
+
+		$apiCall
+			->expects($this->once())
+			->method('setServer')
+			->with('https://api.onoffice.de/api/');
+
+		$cache = $this->getMockBuilder(\onOffice\SDK\Cache\onOfficeSDKCache::class)
+			->getMock();
+
+		$apiCall
+			->expects($this->once())
+			->method('addCache')
+			->with($cache);
+
+		$onOfficeSdk = new \onOffice\SDK\onOfficeSDK($apiCall);
+
+		$onOfficeSdk->addCache($cache);
+	}
+}


### PR DESCRIPTION
This will add the first real unit test, in this case we will add a test case for `onOfficeSDK`.
I needed to inject the dependency to `ApiCall` on order to test this properly and not to send some HTTP Requests via our CI pipeline to the official onOffice API.

I already prepared some more tests locally 🎉 
