### PR TITLE
Add PSR-4 autoloader for tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     },
     "autoload": {
         "psr-4": {
-            "onOffice\\SDK\\": "src"
+            "onOffice\\SDK\\": "src",
+            "Tests\\onOffice\\SDK\\": "tests"
         }
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,11 @@
     },
     "autoload": {
         "psr-4": {
-            "onOffice\\SDK\\": "src",
+            "onOffice\\SDK\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Tests\\onOffice\\SDK\\": "tests"
         }
     },


### PR DESCRIPTION
This issue was discovered via PHPstan in #17 .
We already have the namespaces defined in every test in the `tests` folder, so it makes sense to define the namespace via composer itself.