### PR TITLE
Move example.php to dedicated examples folder 

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $pSDK->sendRequests('put the token here', 'and secret here');
 var_export($pSDK->getResponseArray($handleReadEstate));
 ```
 
-Checkout the [example](/example.php) to see a possible implementation of
+Checkout the [examples folder](/examples/) to see a possible implementation of
 this client.
 
 ## Usage

--- a/examples/01-call-generic.php
+++ b/examples/01-call-generic.php
@@ -41,16 +41,3 @@ $handleReadEstate = $pSDK->callGeneric(onOfficeSDK::ACTION_ID_READ, 'estate', $p
 $pSDK->sendRequests('put the token here', 'and secret here');
 
 var_export($pSDK->getResponseArray($handleReadEstate));
-
-
-// Sometimes however, you will have to set the `resourceId` parameter. In This case, you can use the call() method.
-// Example:
-
-$parametersSearchEstate = [
-	'input' => 'Aachen',
-];
-
-$handleSearchEstate = $pSDK->call(onOfficeSDK::ACTION_ID_GET, 'estate', '', 'search', $parametersSearchEstate);
-$pSDK->sendRequests('put the token here', 'and secret here');
-
-var_export($pSDK->getResponseArray($handleSearchEstate));

--- a/examples/02-call.php
+++ b/examples/02-call.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ *
+ * @url http://www.onoffice.de
+ * @copyright 2016-2018, onOffice(R) GmbH
+ * @license MIT
+ *
+ */
+
+include __DIR__ . '/../vendor/autoload.php';
+
+use onOffice\SDK\onOfficeSDK;
+
+$pSDK = new onOfficeSDK();
+$pSDK->setApiVersion('latest');
+
+$parametersReadEstate = [
+	'data' => [
+		'Id',
+		'kaufpreis',
+		'lage',
+	],
+	'listlimit' => 10,
+	'sortby' => [
+		'kaufpreis' => 'ASC',
+		'warmmiete' => 'ASC',
+	],
+	'filter' => [
+		'kaufpreis' => [
+			['op' => '>', 'val' => 300000],
+		],
+		'status' => [
+			['op' => '=', 'val' => 1],
+		],
+	],
+];
+
+
+$parametersSearchEstate = [
+	'input' => 'Aachen',
+];
+
+$handleSearchEstate = $pSDK->call(onOfficeSDK::ACTION_ID_GET, 'estate', '', 'search', $parametersSearchEstate);
+
+$pSDK->sendRequests('put the token here', 'and secret here');
+
+var_export($pSDK->getResponseArray($handleSearchEstate));

--- a/examples/example.php
+++ b/examples/example.php
@@ -8,7 +8,7 @@
  *
  */
 
-include __DIR__ . '/vendor/autoload.php';
+include __DIR__ . '/../vendor/autoload.php';
 
 use onOffice\SDK\onOfficeSDK;
 


### PR DESCRIPTION
This creates the possibility to add additional examples e.g. calls to `marketplace`

Additional I separated the current example into two files, because these were already two examples in one file.