### PR TITLE
Get rid of useless p-prefix in member variables

### DIFF
--- a/examples/01-call-generic.php
+++ b/examples/01-call-generic.php
@@ -12,8 +12,8 @@ include __DIR__ . '/../vendor/autoload.php';
 
 use onOffice\SDK\onOfficeSDK;
 
-$pSDK = new onOfficeSDK();
-$pSDK->setApiVersion('latest');
+$sdk = new onOfficeSDK();
+$sdk->setApiVersion('latest');
 
 $parametersReadEstate = [
 	'data' => [
@@ -36,8 +36,8 @@ $parametersReadEstate = [
 	],
 ];
 
-$handleReadEstate = $pSDK->callGeneric(onOfficeSDK::ACTION_ID_READ, 'estate', $parametersReadEstate);
+$handleReadEstate = $sdk->callGeneric(onOfficeSDK::ACTION_ID_READ, 'estate', $parametersReadEstate);
 
-$pSDK->sendRequests('put the token here', 'and secret here');
+$sdk->sendRequests('put the token here', 'and secret here');
 
-var_export($pSDK->getResponseArray($handleReadEstate));
+var_export($sdk->getResponseArray($handleReadEstate));

--- a/examples/02-call.php
+++ b/examples/02-call.php
@@ -12,8 +12,8 @@ include __DIR__ . '/../vendor/autoload.php';
 
 use onOffice\SDK\onOfficeSDK;
 
-$pSDK = new onOfficeSDK();
-$pSDK->setApiVersion('latest');
+$sdk = new onOfficeSDK();
+$sdk->setApiVersion('latest');
 
 $parametersReadEstate = [
 	'data' => [
@@ -41,8 +41,8 @@ $parametersSearchEstate = [
 	'input' => 'Aachen',
 ];
 
-$handleSearchEstate = $pSDK->call(onOfficeSDK::ACTION_ID_GET, 'estate', '', 'search', $parametersSearchEstate);
+$handleSearchEstate = $sdk->call(onOfficeSDK::ACTION_ID_GET, 'estate', '', 'search', $parametersSearchEstate);
 
-$pSDK->sendRequests('put the token here', 'and secret here');
+$sdk->sendRequests('put the token here', 'and secret here');
 
-var_export($pSDK->getResponseArray($handleSearchEstate));
+var_export($sdk->getResponseArray($handleSearchEstate));

--- a/src/onOfficeSDK.php
+++ b/src/onOfficeSDK.php
@@ -69,19 +69,19 @@ class onOfficeSDK
 	const RELATION_TYPE_ESTATE_ADDRESS_OWNER = 'urn:onoffice-de-ns:smart:2.5:relationTypes:estate:address:owner';
 
 	/** @var ApiCall */
-	private $_pApiCall = null;
+	private $apiCall = null;
 
 	/**
-	 * @param ApiCall|null $pApiCall
+	 * @param ApiCall|null $apiCall
 	 */
 
-	public function __construct(ApiCall $pApiCall = null)
+	public function __construct(ApiCall $apiCall = null)
 	{
-		if (null === $pApiCall) {
-			$pApiCall = new ApiCall();
+		if (null === $apiCall) {
+			$apiCall = new ApiCall();
 		}
-		$this->_pApiCall = $pApiCall;
-		$this->_pApiCall->setServer('https://api.onoffice.de/api/');
+		$this->apiCall = $apiCall;
+		$this->apiCall->setServer('https://api.onoffice.de/api/');
 	}
 
 
@@ -93,7 +93,7 @@ class onOfficeSDK
 
 	public function setApiVersion($apiVersion)
 	{
-		$this->_pApiCall->setApiVersion($apiVersion);
+		$this->apiCall->setApiVersion($apiVersion);
 	}
 
 
@@ -106,7 +106,7 @@ class onOfficeSDK
 
 	public function setApiServer($server)
 	{
-		$this->_pApiCall->setServer($server);
+		$this->apiCall->setServer($server);
 	}
 
 
@@ -119,7 +119,7 @@ class onOfficeSDK
 
 	public function setApiCurlOptions($curlOptions)
 	{
-		$this->_pApiCall->setCurlOptions($curlOptions);
+		$this->apiCall->setCurlOptions($curlOptions);
 	}
 
 
@@ -135,7 +135,7 @@ class onOfficeSDK
 
 	public function callGeneric($actionId, $resourceType, $parameters)
 	{
-		return $this->_pApiCall->callByRawData($actionId, '', '', $resourceType, $parameters);
+		return $this->apiCall->callByRawData($actionId, '', '', $resourceType, $parameters);
 	}
 
 
@@ -152,7 +152,7 @@ class onOfficeSDK
 
 	public function call($actionId, $resourceId, $identifier, $resourceType, $parameters)
 	{
-		return $this->_pApiCall->callByRawData
+		return $this->apiCall->callByRawData
 			($actionId, $resourceId, $identifier, $resourceType, $parameters);
 	}
 
@@ -166,7 +166,7 @@ class onOfficeSDK
 
 	public function sendRequests($token, $secret)
 	{
-		$this->_pApiCall->sendRequests($token, $secret);
+		$this->apiCall->sendRequests($token, $secret);
 	}
 
 
@@ -179,7 +179,7 @@ class onOfficeSDK
 
 	public function getResponseArray($number)
 	{
-		return $this->_pApiCall->getResponse($number);
+		return $this->apiCall->getResponse($number);
 	}
 
 
@@ -191,7 +191,7 @@ class onOfficeSDK
 
 	public function addCache(onOfficeSDKCache $pCache)
 	{
-		$this->_pApiCall->addCache($pCache);
+		$this->apiCall->addCache($pCache);
 	}
 
 
@@ -203,7 +203,7 @@ class onOfficeSDK
 
 	public function setCaches(array $cacheInstances)
 	{
-		array_map(array($this->_pApiCall, 'addCache'), $cacheInstances);
+		array_map(array($this->apiCall, 'addCache'), $cacheInstances);
 	}
 
 
@@ -213,7 +213,7 @@ class onOfficeSDK
 
 	public function removeCacheInstances()
 	{
-		$this->_pApiCall->removeCacheInstances();
+		$this->apiCall->removeCacheInstances();
 	}
 
 
@@ -225,6 +225,6 @@ class onOfficeSDK
 
 	public function getErrors()
 	{
-		return $this->_pApiCall->getErrors();
+		return $this->apiCall->getErrors();
 	}
 }


### PR DESCRIPTION
The prefix `p` does not mean anything, does not improve the readability and only lead to more questions,  what this is.

So let's get rid of it :)