### PR TITLE
Replace latest API version with stable API version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ supported by the onOffice GmbH.
 
 ```php
 $sdk = new onOfficeSDK();
-$sdk->setApiVersion('latest');
+$sdk->setApiVersion('stable');
 
 $parametersReadEstate = [
 	'data' => [
@@ -68,11 +68,11 @@ receiving HTTP Responses from the official API
 
 ```php
 $sdk = new onOfficeSDK();
-$sdk->setApiVersion('latest');
+$sdk->setApiVersion('stable');
 ```
 
 Make sure that the correct API version is used for your client.
-By default this value is set to `latest`.
+By default this value is set to `stable`.
 
 ### Parameters
 

--- a/examples/01-call-generic.php
+++ b/examples/01-call-generic.php
@@ -13,7 +13,7 @@ include __DIR__ . '/../vendor/autoload.php';
 use onOffice\SDK\onOfficeSDK;
 
 $sdk = new onOfficeSDK();
-$sdk->setApiVersion('latest');
+$sdk->setApiVersion('stable');
 
 $parametersReadEstate = [
 	'data' => [

--- a/examples/02-call.php
+++ b/examples/02-call.php
@@ -13,7 +13,7 @@ include __DIR__ . '/../vendor/autoload.php';
 use onOffice\SDK\onOfficeSDK;
 
 $sdk = new onOfficeSDK();
-$sdk->setApiVersion('latest');
+$sdk->setApiVersion('stable');
 
 $parametersReadEstate = [
 	'data' => [

--- a/examples/03-marketplace-unlock-provider.php
+++ b/examples/03-marketplace-unlock-provider.php
@@ -5,7 +5,7 @@ include __DIR__ . '/../vendor/autoload.php';
 use onOffice\SDK\onOfficeSDK;
 
 $pSDK = new onOfficeSDK();
-$pSDK->setApiVersion('latest');
+$pSDK->setApiVersion('stable');
 
 $parameterCacheId = '<insert parameterCacheId from IFrame url>';
 

--- a/src/internal/ApiCall.php
+++ b/src/internal/ApiCall.php
@@ -35,7 +35,7 @@ class ApiCall
 	private $_errors = array();
 
 	/** @var string */
-	private $_apiVersion = 'latest';
+	private $_apiVersion = 'stable';
 
 	/** @var onOfficeSDKCache[] */
 	private $_caches = array();


### PR DESCRIPTION
So we asked a bit around and maybe it makes sense to change the API version from `latest` to `stable` in these code examples.

The reason is, that it seems that the most people using this API are internally using the `stable` version independent if `latest` is given here. IMO it makes more sense to make `stable` the default for this library to avoid internal redirects.

@jayay does this PR makes sense? 