### PR TITLE
Fix namespace of test class

### DIFF
--- a/tests/onOfficeSDKTest.php
+++ b/tests/onOfficeSDKTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\onOffice\SDK;
+
 class onOfficeSDKTest extends \PHPUnit\Framework\TestCase
 {
 	public function testCreationOfClient()


### PR DESCRIPTION
I noticed this while attempting to run phpstan locally. This was the only error preventing phpstan to run through.