### PR TITLE
Remove unused variable

### DIFF
--- a/examples/02-call.php
+++ b/examples/02-call.php
@@ -15,28 +15,6 @@ use onOffice\SDK\onOfficeSDK;
 $sdk = new onOfficeSDK();
 $sdk->setApiVersion('stable');
 
-$parametersReadEstate = [
-	'data' => [
-		'Id',
-		'kaufpreis',
-		'lage',
-	],
-	'listlimit' => 10,
-	'sortby' => [
-		'kaufpreis' => 'ASC',
-		'warmmiete' => 'ASC',
-	],
-	'filter' => [
-		'kaufpreis' => [
-			['op' => '>', 'val' => 300000],
-		],
-		'status' => [
-			['op' => '=', 'val' => 1],
-		],
-	],
-];
-
-
 $parametersSearchEstate = [
 	'input' => 'Aachen',
 ];


### PR DESCRIPTION
The variable `$parametersReadEstate` is unused and just confusing. Using it together with the `call` function with the arguments of the example would also not work.