### PR TITLE
now initializing the timestamp parameter in case it is not set manually

### DIFF
--- a/src/internal/Request.php
+++ b/src/internal/Request.php
@@ -52,12 +52,13 @@ class Request
 	public function createRequest($token, $secret)
 	{
 		$actionParameters = $this->_pApiAction->getActionParameters();
-		$timestamp = $actionParameters['timestamp'] ?? time();
+
+		$actionParameters['timestamp'] = $actionParameters['timestamp'] ?? time();
 		$actionParameters['hmac_version'] = 2;
 
 		$actionId = $actionParameters['actionid'];
 		$type = $actionParameters['resourcetype'];
-		$hmac = $this->createHmac2( $token, $secret, $timestamp, $type, $actionId);
+		$hmac = $this->createHmac2( $token, $secret, $actionParameters['timestamp'], $type, $actionId);
 		$actionParameters['hmac'] = $hmac;
 
 		return $actionParameters;

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -40,7 +40,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
 		$request = new Request($apiAction);
 		$result = $request->createRequest($token, $secret);
 
-		$this->assertGreaterThan(0, $result['timestamp']);
+		$this->assertEquals(123456789, $result['timestamp']);
 		$this->assertEquals('someResourceId', $result['resourceid']);
 		$this->assertEquals('someIdentifier', $result['identifier']);
 		$this->assertEquals([], $result['parameters']);
@@ -48,6 +48,32 @@ class RequestTest extends \PHPUnit\Framework\TestCase
 		$this->assertEquals('estateCategories', $result['resourcetype']);
 		$this->assertGreaterThanOrEqual(2, $result['hmac_version']);
 		$this->assertEquals('dsvg3r4AFcQXges0MZ+3auzQVfnEB39pLkKSgmm9Wvg=', $result['hmac']);
+	}
+
+	public function testCreateRequest_noTimestamp()
+	{
+		$secret = 'yOJobbhGLXdp90XxvxedFhH7073L9U';
+		$token = 'mgjIQkNRnaqggVzy9cZW';
+
+		$apiAction = new ApiAction(
+			'urn:onoffice-de-ns:smart:2.5:smartml:action:get',
+			'estateCategories',
+			[],
+			'someResourceId',
+			'someIdentifier'
+		);
+
+		$request = new Request($apiAction);
+		$result = $request->createRequest($token, $secret);
+
+		$this->assertGreaterThan(0, $result['timestamp']);
+		$this->assertEquals('someResourceId', $result['resourceid']);
+		$this->assertEquals('someIdentifier', $result['identifier']);
+		$this->assertEquals([], $result['parameters']);
+		$this->assertEquals('urn:onoffice-de-ns:smart:2.5:smartml:action:get', $result['actionid']);
+		$this->assertEquals('estateCategories', $result['resourcetype']);
+		$this->assertGreaterThanOrEqual(2, $result['hmac_version']);
+		$this->assertNotEmpty( $result['hmac']);
 	}
 
 	public function testGetRequestId()


### PR DESCRIPTION
fixes #2914681, where the timestamp may become null