### PR TITLE
Add integration test

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -24,6 +24,8 @@ jobs:
       with:
         php-version: ${{ matrix.php }}
 
+    - run: sudo apt-get update && sudo apt-get install faketime nmap
+
     - name: Validate composer.json and composer.lock
       run: composer validate --strict
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,8 @@ The list of maintainers can be found [here](https://github.com/orgs/onOfficeGmbH
   general behaviour.
 * Contact one of the maintainers in the Pull Request.
   The list of maintainers can be found [here](https://github.com/orgs/onOfficeGmbH/people)
-* Every Pull Request with actual code changes has to add or adapt unit tests.
+* Every Pull Request with actual code changes has to add or adapt unit and/or integration tests. 
+  Please see [Running the Tests](#running-the-tests) down below.
 * Create a meaningful title for the Pull Request that addresses the topic.
 * The Pull Request must pass the CI integration.
   Be aware of the currently supported PHP versions and optimize your code according
@@ -47,3 +48,12 @@ The list of maintainers can be found [here](https://github.com/orgs/onOfficeGmbH
   Try always to create the best possible solution.
 * Use readable and understandable commit messages, so the reviewer can understand the
   intention of each commit.
+
+## Running the Tests
+
+The tests of this project consist on two [test suites](https://phpunit.readthedocs.io/en/9.5/organizing-tests.html).
+These are named _unit_ and _integration_ for unit tests and integration tests, respectively.
+Running the unit tests should be no harder that running
+`./vendor/bin/phpunit --testsuite unit`,  while executing the integration tests requires the binaries `faketime` and `ncat`
+to be in the `$PATH`. The integration tests can be run by typing
+`./vendor/bin/phpunit --testsuite integration`.

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     },
     "require-dev": {
       "phpunit/phpunit": "^6",
-      "friendsofphp/php-cs-fixer": "^2.16"
+      "friendsofphp/php-cs-fixer": "^2.16",
+      "symfony/process": "^3.4.37"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,11 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "hash": "53158b5088e9005118682b2d675e1d72",
-    "content-hash": "d511557870b808bb3bf43642aedc826b",
+    "content-hash": "8635cdfd9dffe42765d3483b7a326420",
     "packages": [],
     "packages-dev": [
         {
@@ -67,7 +66,7 @@
                 "validation",
                 "versioning"
             ],
-            "time": "2020-01-13 12:06:48"
+            "time": "2020-01-13T12:06:48+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -111,7 +110,7 @@
                 "Xdebug",
                 "performance"
             ],
-            "time": "2019-11-06 16:40:04"
+            "time": "2019-11-06T16:40:04+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -179,7 +178,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2017-02-24 16:22:25"
+            "time": "2017-02-24T16:22:25+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -233,7 +232,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -293,7 +292,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2019-06-08 11:03:04"
+            "time": "2019-06-08T11:03:04+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",
@@ -382,7 +381,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2019-11-25 22:10:32"
+            "time": "2019-11-25T22:10:32+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -427,7 +426,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-10-19 19:58:43"
+            "time": "2017-10-19T19:58:43+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -472,7 +471,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2018-07-02 15:55:56"
+            "time": "2018-07-02T15:55:56+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -527,7 +526,7 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2017-03-05 18:14:27"
+            "time": "2017-03-05T18:14:27+00:00"
         },
         {
             "name": "phar-io/version",
@@ -574,7 +573,7 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2017-03-05 17:38:23"
+            "time": "2017-03-05T17:38:23+00:00"
         },
         {
             "name": "php-cs-fixer/diff",
@@ -625,7 +624,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2018-02-15 16:58:55"
+            "time": "2018-02-15T16:58:55+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -679,7 +678,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-09-11 18:02:19"
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -731,7 +730,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2019-12-28 18:55:12"
+            "time": "2019-12-28T18:55:12+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -776,7 +775,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-12-30 13:23:38"
+            "time": "2017-12-30T13:23:38+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -839,7 +838,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2020-01-20 15:57:02"
+            "time": "2020-01-20T15:57:02+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -902,7 +901,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-04-06 15:36:58"
+            "time": "2018-04-06T15:36:58+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -949,7 +948,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2017-11-27 13:52:08"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -990,7 +989,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -1039,7 +1038,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26 11:10:40"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -1088,7 +1087,8 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-11-27 05:48:46"
+            "abandoned": true,
+            "time": "2017-11-27T05:48:46+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -1172,7 +1172,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-02-01 05:22:47"
+            "time": "2019-02-01T05:22:47+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1232,7 +1232,7 @@
                 "xunit"
             ],
             "abandoned": true,
-            "time": "2018-08-09 05:50:03"
+            "time": "2018-08-09T05:50:03+00:00"
         },
         {
             "name": "psr/log",
@@ -1279,7 +1279,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2019-11-01 11:05:21"
+            "time": "2019-11-01T11:05:21+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1324,7 +1324,7 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04 06:30:41"
+            "time": "2017-03-04T06:30:41+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -1388,7 +1388,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2018-02-01 13:46:46"
+            "time": "2018-02-01T13:46:46+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -1440,7 +1440,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2017-08-03 08:09:46"
+            "time": "2017-08-03T08:09:46+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1490,7 +1490,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2017-07-01 08:51:00"
+            "time": "2017-07-01T08:51:00+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1557,7 +1557,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2019-09-14 09:02:43"
+            "time": "2019-09-14T09:02:43+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1608,7 +1608,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2017-04-27 15:39:26"
+            "time": "2017-04-27T15:39:26+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -1655,7 +1655,7 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-08-03 12:35:26"
+            "time": "2017-08-03T12:35:26+00:00"
         },
         {
             "name": "sebastian/object-reflector",
@@ -1700,7 +1700,7 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2017-03-29 09:07:27"
+            "time": "2017-03-29T09:07:27+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -1753,7 +1753,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2017-03-03 06:23:57"
+            "time": "2017-03-03T06:23:57+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -1795,7 +1795,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28 20:34:47"
+            "time": "2015-07-28T20:34:47+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1838,7 +1838,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03 07:35:21"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "symfony/console",
@@ -1910,7 +1910,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2020-01-10 07:52:48"
+            "time": "2020-01-10T07:52:48+00:00"
         },
         {
             "name": "symfony/debug",
@@ -1966,7 +1966,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2020-01-08 16:36:15"
+            "time": "2020-01-08T16:36:15+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -2029,7 +2029,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2020-01-04 12:05:51"
+            "time": "2020-01-04T12:05:51+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -2079,7 +2079,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2020-01-17 08:50:08"
+            "time": "2020-01-17T08:50:08+00:00"
         },
         {
             "name": "symfony/finder",
@@ -2128,7 +2128,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2020-01-01 11:03:25"
+            "time": "2020-01-01T11:03:25+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -2182,7 +2182,7 @@
                 "configuration",
                 "options"
             ],
-            "time": "2020-01-01 11:03:25"
+            "time": "2020-01-01T11:03:25+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2240,7 +2240,7 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-11-27 13:56:44"
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -2299,7 +2299,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-01-13 11:15:53"
+            "time": "2020-01-13T11:15:53+00:00"
         },
         {
             "name": "symfony/polyfill-php70",
@@ -2358,7 +2358,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-01-13 11:15:53"
+            "time": "2020-01-13T11:15:53+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
@@ -2413,7 +2413,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-01-13 11:15:53"
+            "time": "2020-01-13T11:15:53+00:00"
         },
         {
             "name": "symfony/process",
@@ -2462,7 +2462,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2020-01-01 11:03:25"
+            "time": "2020-01-01T11:03:25+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -2511,7 +2511,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2020-01-01 11:03:25"
+            "time": "2020-01-01T11:03:25+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2551,19 +2551,19 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2019-06-13 22:48:21"
+            "time": "2019-06-13T22:48:21+00:00"
         },
         {
             "name": "webmozart/assert",
             "version": "1.6.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
+                "url": "https://github.com/webmozarts/assert.git",
                 "reference": "573381c0a64f155a0d9a23f4b0c797194805b925"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/573381c0a64f155a0d9a23f4b0c797194805b925",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/573381c0a64f155a0d9a23f4b0c797194805b925",
                 "reference": "573381c0a64f155a0d9a23f4b0c797194805b925",
                 "shasum": ""
             },
@@ -2599,7 +2599,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2019-11-24 13:36:37"
+            "time": "2019-11-24T13:36:37+00:00"
         }
     ],
     "aliases": [],
@@ -2611,5 +2611,6 @@
         "ext-json": "*",
         "ext-curl": "*"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,8 +12,14 @@
          bootstrap="vendor/autoload.php"
 >
     <testsuites>
-        <testsuite name="Test Suite">
+        <testsuite name="unit">
             <directory>./tests/</directory>
+            <filter>
+                <exclude>./tests/SDKIntegrationTest.php</exclude>
+            </filter>
+        </testsuite>
+        <testsuite name="integration">
+            <file>./tests/SDKIntegrationTest.php</file>
         </testsuite>
     </testsuites>
 

--- a/tests/SDKIntegrationTest.php
+++ b/tests/SDKIntegrationTest.php
@@ -52,11 +52,22 @@ class SDKIntegrationTest extends \PHPUnit\Framework\TestCase
             'datestart' => '25-03-2022 02:17:53',
             'showcancelled' => true
         ]);
+
+        // sleep at most one second to send the request at timestamp 1646228220        
+        $current = microtime(true);
+        $expected = (new \DateTime('2022-03-02 13:37:00 UTC'))->format('U');
+
+        $sleepTimeMicroSeconds = $expected - $current;
+
+        if ($sleepTimeMicroSeconds > 0) {
+            usleep(intval($sleepTimeMicroSeconds * 1000000));
+        }        
+        
         $sdk->sendRequests('testtoken', 'testsecret');
 EOS;
 
         sleep(2);
-        $php = new Process(['faketime', '2022-03-02 13:37:00 UTC', 'php', '-r', $script], dirname(__DIR__));
+        $php = new Process(['faketime', '2022-03-02 13:36:59 UTC', 'php', '-r', $script], dirname(__DIR__));
         $php->setTimeout(2);
         $php->setIdleTimeout(2);
         $php->start();

--- a/tests/SDKIntegrationTest.php
+++ b/tests/SDKIntegrationTest.php
@@ -1,0 +1,104 @@
+<?php
+
+
+namespace Tests\onOffice\SDK;
+
+use Symfony\Component\Process\Process;
+
+class SDKIntegrationTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * tests if faketime package is available
+     */
+    public function test_faketime_available()
+    {
+        $process = new Process(['which', 'faketime']);
+        $process->run();
+        $this->assertSame(0, $process->getExitCode());
+    }
+
+    /**
+     * @depends test_faketime_available
+     * Tests if ncat from nmap package is installed
+     */
+    public function test_ncat_available()
+    {
+        $process = new Process(['which', 'ncat']);
+        $process->run();
+        $this->assertSame(0, $process->getExitCode());
+    }
+
+
+    /**
+     * @depends test_ncat_available
+     */
+    public function test_request_structure_correct()
+    {
+        $ncat = new Process(['sudo', 'ncat', '-n', '--ssl', '-l', '1234', '-i', '1', '-4']);
+        $ncat->setTimeout(5);
+        $ncat->setIdleTimeout(5);
+
+        $ncat->start();
+
+        $script = <<<'EOS'
+        require_once 'vendor/autoload.php';
+        $sdk = new \onOffice\SDK\onOfficeSDK();
+        $sdk->setApiVersion('latest');
+        $sdk->setApiServer('https://localhost:1234/api/');
+        $sdk->setApiCurlOptions([CURLOPT_SSL_VERIFYPEER => false, CURLOPT_SSL_VERIFYHOST => false]);
+        $sdk->call(\onOffice\SDK\onOfficeSDK::ACTION_ID_READ, '', null, 'calendar', [
+            'allusers' => false,
+            'dateend' => '25-03-2022 02:17:53',
+            'datestart' => '25-03-2022 02:17:53',
+            'showcancelled' => true
+        ]);
+        $sdk->sendRequests('testtoken', 'testsecrect');
+EOS;
+
+        sleep(2);
+        $php = new Process(['faketime', '2022-03-02 13:37:00 UTC', 'php', '-r', $script], dirname(__DIR__));
+        $php->setTimeout(2);
+        $php->setIdleTimeout(2);
+        $php->start();
+
+        $this->assertTrue($ncat->isStarted());
+
+        if ($php->isTerminated())
+        {
+            $this->fail('PHP terminated');
+            return;
+        }
+
+        while ($ncat->isRunning() || $php->isRunning()) {
+            try {
+                $php->checkTimeout();
+                $ncat->checkTimeout();
+            } catch (\Symfony\Component\Process\Exception\ProcessTimedOutException $e) {
+                $this->fail('Process took too long. //// ' . $php->getErrorOutput(). ' //// '. $ncat->getErrorOutput());
+                break;
+            }
+
+            if ($ncat->getOutput() !== '') {
+                $ncat->stop(0, 2);
+                $php->stop(0, 2);
+            }
+        }
+
+        $this->assertTrue($ncat->isTerminated());
+        $this->assertTrue($php->isTerminated());
+
+        $this->assertSame('', $ncat->getErrorOutput());
+
+        $output = $ncat->getOutput();
+        $expectedOutput =
+            'POST /api/latest/api.php HTTP/1.1'."\r\n"
+            .'Host: localhost:1234'."\r\n"
+            .'Accept: */*'."\r\n"
+            .'Accept-Encoding: deflate, gzip'."\r\n"
+            .'Content-Length: 382'."\r\n"
+            .'Content-Type: application/x-www-form-urlencoded'."\r\n"
+            ."\r\n"
+            .'{"token":"testtoken","request":{"actions":[{"actionid":"urn:onoffice-de-ns:smart:2.5:smartml:action:read","identifier":null,"parameters":{"allusers":false,"dateend":"25-03-2022 02:17:53","datestart":"25-03-2022 02:17:53","showcancelled":true},"resourceid":"","resourcetype":"calendar","timestamp":1646228220,"hmac_version":2,"hmac":"xEtO1ptCf+CKWsVPB+9AM+EM91uB2tc17VIUuVorYOA="}]}}';
+        $this->assertSame($expectedOutput, $output);
+    }
+}

--- a/tests/SDKIntegrationTest.php
+++ b/tests/SDKIntegrationTest.php
@@ -34,7 +34,7 @@ class SDKIntegrationTest extends \PHPUnit\Framework\TestCase
      */
     public function test_request_structure_correct()
     {
-        $ncat = new Process(['sudo', 'ncat', '-n', '--ssl', '-l', '1234', '-i', '1', '-4']);
+        $ncat = new Process(['ncat', '-n', '--ssl', '-l', '1234', '-i', '1', '-4']);
         $ncat->setTimeout(5);
         $ncat->setIdleTimeout(5);
 

--- a/tests/SDKIntegrationTest.php
+++ b/tests/SDKIntegrationTest.php
@@ -52,7 +52,7 @@ class SDKIntegrationTest extends \PHPUnit\Framework\TestCase
             'datestart' => '25-03-2022 02:17:53',
             'showcancelled' => true
         ]);
-        $sdk->sendRequests('testtoken', 'testsecrect');
+        $sdk->sendRequests('testtoken', 'testsecret');
 EOS;
 
         sleep(2);
@@ -98,7 +98,7 @@ EOS;
             .'Content-Length: 382'."\r\n"
             .'Content-Type: application/x-www-form-urlencoded'."\r\n"
             ."\r\n"
-            .'{"token":"testtoken","request":{"actions":[{"actionid":"urn:onoffice-de-ns:smart:2.5:smartml:action:read","identifier":null,"parameters":{"allusers":false,"dateend":"25-03-2022 02:17:53","datestart":"25-03-2022 02:17:53","showcancelled":true},"resourceid":"","resourcetype":"calendar","timestamp":1646228220,"hmac_version":2,"hmac":"xEtO1ptCf+CKWsVPB+9AM+EM91uB2tc17VIUuVorYOA="}]}}';
+            .'{"token":"testtoken","request":{"actions":[{"actionid":"urn:onoffice-de-ns:smart:2.5:smartml:action:read","identifier":null,"parameters":{"allusers":false,"dateend":"25-03-2022 02:17:53","datestart":"25-03-2022 02:17:53","showcancelled":true},"resourceid":"","resourcetype":"calendar","timestamp":1646228220,"hmac_version":2,"hmac":"w6ifKMmAdJoKhu0vl2twvfP+ltyOTQ7LqLpvsZkOnlg="}]}}';
         $this->assertSame($expectedOutput, $output);
     }
 }


### PR DESCRIPTION
This integration test spawns a little HTTP server with SSL and another subprocess with PHP, controlled by `faketime`, which fakes the current time for the PHP process it has control over.

In that way, we have the possibility to create reproducible requests, and to monitor behavioral changes in the requests sent to our API. The sent request can be observed and tested for certain traits in the unit test, or be compared as a whole in the way it is right now.

**known bugs**
~If the PHP subprocess takes longer than one second to send the request, the timestamp might be off, also leading to a different HMAC.~ Fixed in 1a58577