### PR TITLE
Adding section to distinguish between call and callGeneric

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,22 @@ var_export($sdk->getResponseArray($handleReadEstate));
 
 The response will be a PHP array.
 
+### Difference between `call` and `callGeneric`
+
+This library will provide two general methods that to create the calls to the onOffice API.
+
+* `callGeneric` is used to create simple calls e.g. 
+   [Estate searches](https://apidoc.onoffice.de/actions/datensatz-lesen/objekte/)
+   or
+  [reading addresses](https://apidoc.onoffice.de/actions/datensatz-lesen/adressen/)
+* `call` can be used more specific for special API Requests.
+  Some API Request need some more information like `identifier`, `resourceId` and `resourceType`
+  to be processed.
+  This can be calls like [Estate files](https://apidoc.onoffice.de/actions/informationen-abfragen/objektdateien/)
+  or [Editing Addresses](https://apidoc.onoffice.de/actions/datensatz-bearbeiten/addresses/)
+
+Check the [API documentation](#api-documentation) for more information.
+
 ## API Documentation
 
 The API client is developed for the latest version of the official API.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ This library will provide two general methods to create the calls to the onOffic
 * `call` can be used more specific for special API Requests.
   Some API Request need some more information like `identifier`, `resourceId` and `resourceType`
   to be processed.
-  This can be calls like [Estate files](https://apidoc.onoffice.de/actions/informationen-abfragen/objektdateien/)
+  These can be calls like [Estate files](https://apidoc.onoffice.de/actions/informationen-abfragen/objektdateien/)
   or [Editing Addresses](https://apidoc.onoffice.de/actions/datensatz-bearbeiten/addresses/)
 
 Check the [API documentation](#api-documentation) for more information.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The response will be a PHP array.
 
 ### Difference between `call` and `callGeneric`
 
-This library will provide two general methods that to create the calls to the onOffice API.
+This library will provide two general methods to create the calls to the onOffice API.
 
 * `callGeneric` is used to create simple calls e.g. 
    [Estate searches](https://apidoc.onoffice.de/actions/datensatz-lesen/objekte/)


### PR DESCRIPTION
Adding a hint for users of the SDK what the difference between `call` and `callGeneric` is, in order to make it easier to use the library.