### PR TITLE
Set PHP minimum version to 7.2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Official client to communicate with the onOffice API",
     "license": "MIT",
     "require": {
+        "php": ">=7.2.5",
         "ext-json": "*",
         "ext-curl": "*"
     },


### PR DESCRIPTION
This is in line with the requirements of the dependencies and the latest stable composer version. PHP versions older than that are also long past their EOL. The 0.3.0 release has to be compatible with PHP 7 still.